### PR TITLE
Fix Recursive Invariants

### DIFF
--- a/certora/specs/Calldata.spec
+++ b/certora/specs/Calldata.spec
@@ -17,10 +17,11 @@ invariant calldataIndexesInvariant(address contract, bytes4 selector, uint256 in
     (
         t._calldataList[contract][selector][index].startIndex >= 4 &&
         t._calldataList[contract][selector][index].endIndex >= t._calldataList[contract][selector][index].startIndex
-    )
-        filtered {
-            f -> f.selector != sig:removeCalldataCheck(address,bytes4,uint256).selector
+    ) {
+        preserved {
+            requireInvariant calldataIndexesInvariant(contract, selector, assert_uint256(t._calldataList[contract][selector].length - 1));
         }
+    }
 
 invariant singleCheckIfWildcard(address contract, bytes4 selector, uint256 index)
     (t._calldataList[contract][selector].length > index && 
@@ -28,10 +29,11 @@ invariant singleCheckIfWildcard(address contract, bytes4 selector, uint256 index
     (
        t._calldataList[contract][selector][index].startIndex == 4 &&
        t._calldataList[contract][selector].length == 1
-    )
-        filtered {
-            f -> f.selector != sig:removeCalldataCheck(address,bytes4,uint256).selector
+    ) {
+        preserved {
+            requireInvariant singleCheckIfWildcard(contract, selector, assert_uint256(t._calldataList[contract][selector].length - 1));
         }
+    }
 
 /// removeCalldataCheck removes 1 calldata check
 rule removeCalldataCheck(env e, address target, bytes4 selector, uint256 index) {


### PR DESCRIPTION
Make invariants recursive if there are more than 1 calldata checks so that function `removeCalldataChecks` does not need to be filtered out. https://prover.certora.com/output/651303/1cedecdb90b649bdbe93b739ebf2981c/?anonymousKey=15ba36ed9f97553a5d27f8fe44145539cece8da7

calldata specification run: https://prover.certora.com/output/651303/9d85392355ac4ab7991a75f33f3acfaf?anonymousKey=89232d2818cb66b8c457f23302c88bc0ac234ad1