### PR TITLE
Fix RecoverySpell execution when recovery owner overlaps final Safe owner

### DIFF
--- a/src/RecoverySpell.sol
+++ b/src/RecoverySpell.sol
@@ -246,11 +246,12 @@ contract RecoverySpell is EIP712("Recovery Spell", "0.1.0") {
         address[] memory existingOwners = safe.getOwners();
         uint256 existingOwnersLength = existingOwners.length;
 
-        /// + 1 is for the module removal
-        /// new owner length = 1
-        /// existing owner length = 1
-        IMulticall3.Call3[] memory calls3 =
-            new IMulticall3.Call3[](owners.length + existingOwnersLength + 1);
+        bool firstOwnerAlreadySafeOwner =
+            existingOwners[existingOwnersLength - 1] == owners[0];
+        uint256 swapCallCount = firstOwnerAlreadySafeOwner ? 0 : 1;
+
+        IMulticall3.Call3[] memory calls3 = new IMulticall3
+            .Call3[](owners.length + existingOwnersLength + swapCallCount);
 
         uint256 index = 0;
 
@@ -266,12 +267,15 @@ contract RecoverySpell is EIP712("Recovery Spell", "0.1.0") {
             );
         }
 
-        calls3[index++].callData = abi.encodeWithSelector(
-            OwnerManager.swapOwner.selector,
-            SENTINEL,
-            existingOwners[existingOwnersLength - 1],
-            owners[0]
-        );
+        /// Safe rejects swapOwner(oldOwner, oldOwner) with GS204.
+        if (!firstOwnerAlreadySafeOwner) {
+            calls3[index++].callData = abi.encodeWithSelector(
+                OwnerManager.swapOwner.selector,
+                SENTINEL,
+                existingOwners[existingOwnersLength - 1],
+                owners[0]
+            );
+        }
 
         /// only cover indexes 1 through new owners length
         for (uint256 i = 1; i < owners.length; i++) {

--- a/test/integration/RecoverySpells.t.sol
+++ b/test/integration/RecoverySpells.t.sol
@@ -394,13 +394,13 @@ contract RecoverySpellsIntegrationTest is SystemIntegrationFixture {
         }
     }
 
-    function _enableRecoveryModule(address recovery) internal {
+    function _enableRecoveryModule(address recoveryModule) internal {
         bytes memory calldatas = abi.encodeWithSelector(
             ModuleManager.execTransactionFromModule.selector,
             address(safe),
             0,
             abi.encodeWithSelector(
-                ModuleManager.enableModule.selector, recovery
+                ModuleManager.enableModule.selector, recoveryModule
             ),
             Enum.Operation.Call
         );
@@ -450,7 +450,8 @@ contract RecoverySpellsIntegrationTest is SystemIntegrationFixture {
         timelock.execute(address(safe), 0, calldatas, bytes32(0));
 
         assertTrue(
-            safe.isModuleEnabled(recovery), "recovery spell should be enabled"
+            safe.isModuleEnabled(recoveryModule),
+            "recovery spell should be enabled"
         );
     }
 }

--- a/test/integration/RecoverySpells.t.sol
+++ b/test/integration/RecoverySpells.t.sol
@@ -6,6 +6,8 @@ import {
 
 import "test/utils/SystemIntegrationFixture.sol";
 
+import {RecoverySpellFactory} from "src/RecoverySpellFactory.sol";
+
 contract RecoverySpellsIntegrationTest is SystemIntegrationFixture {
     using BytesHelper for bytes;
 
@@ -260,68 +262,7 @@ contract RecoverySpellsIntegrationTest is SystemIntegrationFixture {
 
         assertTrue(address(recovery).code.length == 0, "recovery spell created");
 
-        /// timelock calls multisig, multisig calls multisig
-
-        bytes memory calldatas = abi.encodeWithSelector(
-            ModuleManager.execTransactionFromModule.selector,
-            address(safe),
-            0,
-            abi.encodeWithSelector(
-                ModuleManager.enableModule.selector, address(recovery)
-            ),
-            Enum.Operation.Call
-        );
-        bytes memory innerCalldatas = abi.encodeWithSelector(
-            Timelock.schedule.selector,
-            address(safe),
-            0,
-            calldatas,
-            /// salt
-            bytes32(0),
-            timelock.minDelay()
-        );
-
-        bytes32 transactionHash = safe.getTransactionHash(
-            address(timelock),
-            0,
-            innerCalldatas,
-            Enum.Operation.Call,
-            0,
-            0,
-            0,
-            address(0),
-            address(0),
-            safe.nonce()
-        );
-
-        bytes memory collatedSignatures =
-            signTxAllOwners(transactionHash, pk1, pk2, pk3);
-
-        safe.checkNSignatures(
-            transactionHash, innerCalldatas, collatedSignatures, 3
-        );
-
-        safe.execTransaction(
-            address(timelock),
-            0,
-            innerCalldatas,
-            Enum.Operation.Call,
-            0,
-            0,
-            0,
-            address(0),
-            payable(address(0)),
-            collatedSignatures
-        );
-
-        vm.warp(block.timestamp + timelock.minDelay());
-
-        timelock.execute(address(safe), 0, calldatas, bytes32(0));
-
-        assertTrue(
-            safe.isModuleEnabled(recoverySpellAddress),
-            "recovery spell should be removed after execution"
-        );
+        _enableRecoveryModule(address(recovery));
         assertEq(
             timelock.getAllProposals().length, 0, "proposal should be removed"
         );
@@ -375,5 +316,141 @@ contract RecoverySpellsIntegrationTest is SystemIntegrationFixture {
         }
 
         return recovery;
+    }
+
+    function testRecoverySpellHandlesFirstRecoveryOwnerAlreadyFinalSafeOwner()
+        public
+    {
+        address[] memory existingOwners = safe.getOwners();
+        address finalSafeOwner = existingOwners[existingOwners.length - 1];
+        vm.etch(finalSafeOwner, "");
+
+        address[] memory overlappingRecoveryOwners =
+            new address[](recoveryOwners.length);
+        overlappingRecoveryOwners[0] = finalSafeOwner;
+
+        for (uint256 i = 1; i < overlappingRecoveryOwners.length; i++) {
+            overlappingRecoveryOwners[i] = recoveryOwners[i];
+        }
+
+        bytes32 overlapSalt = bytes32(uint256(recoverySalt) + 1);
+        RecoverySpellFactory freshRecoveryFactory = new RecoverySpellFactory();
+        RecoverySpell recovery = RecoverySpell(
+            freshRecoveryFactory.calculateAddress(
+                overlapSalt,
+                overlappingRecoveryOwners,
+                address(safe),
+                recoveryThreshold,
+                0,
+                recoveryDelay
+            )
+        );
+
+        _enableRecoveryModule(address(recovery));
+
+        RecoverySpell createdRecovery = freshRecoveryFactory.createRecoverySpell(
+            overlapSalt,
+            overlappingRecoveryOwners,
+            address(safe),
+            recoveryThreshold,
+            0,
+            recoveryDelay
+        );
+
+        assertEq(
+            address(createdRecovery),
+            address(recovery),
+            "expected recovery address not correct"
+        );
+
+        vm.warp(block.timestamp + recoveryDelay + 1);
+        recovery.executeRecovery(
+            address(1), new uint8[](0), new bytes32[](0), new bytes32[](0)
+        );
+
+        assertFalse(
+            safe.isModuleEnabled(address(recovery)),
+            "recovery spell should be removed after execution"
+        );
+        assertEq(safe.getThreshold(), recoveryThreshold, "quorum not updated");
+        assertEq(
+            safe.getOwners().length,
+            overlappingRecoveryOwners.length,
+            "signer list not rotated"
+        );
+
+        for (uint256 i = 0; i < existingOwners.length - 1; i++) {
+            assertFalse(
+                safe.isOwner(existingOwners[i]),
+                "old owner should be removed after recovery"
+            );
+        }
+
+        for (uint256 i = 0; i < overlappingRecoveryOwners.length; i++) {
+            assertTrue(
+                safe.isOwner(overlappingRecoveryOwners[i]),
+                "recovery owner should be an owner"
+            );
+        }
+    }
+
+    function _enableRecoveryModule(address recovery) internal {
+        bytes memory calldatas = abi.encodeWithSelector(
+            ModuleManager.execTransactionFromModule.selector,
+            address(safe),
+            0,
+            abi.encodeWithSelector(
+                ModuleManager.enableModule.selector, recovery
+            ),
+            Enum.Operation.Call
+        );
+        bytes memory innerCalldatas = abi.encodeWithSelector(
+            Timelock.schedule.selector,
+            address(safe),
+            0,
+            calldatas,
+            bytes32(0),
+            timelock.minDelay()
+        );
+
+        bytes32 transactionHash = safe.getTransactionHash(
+            address(timelock),
+            0,
+            innerCalldatas,
+            Enum.Operation.Call,
+            0,
+            0,
+            0,
+            address(0),
+            address(0),
+            safe.nonce()
+        );
+
+        bytes memory collatedSignatures =
+            signTxAllOwners(transactionHash, pk1, pk2, pk3);
+
+        safe.checkNSignatures(
+            transactionHash, innerCalldatas, collatedSignatures, 3
+        );
+
+        safe.execTransaction(
+            address(timelock),
+            0,
+            innerCalldatas,
+            Enum.Operation.Call,
+            0,
+            0,
+            0,
+            address(0),
+            payable(address(0)),
+            collatedSignatures
+        );
+
+        vm.warp(block.timestamp + timelock.minDelay());
+        timelock.execute(address(safe), 0, calldatas, bytes32(0));
+
+        assertTrue(
+            safe.isModuleEnabled(recovery), "recovery spell should be enabled"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Skip the final Safe `swapOwner` when the surviving Safe owner is already `owners[0]`, avoiding `swapOwner(oldOwner, oldOwner)` / `GS204`.
- Size the recovery multicall to include the swap only when it is needed.
- Add a regression integration test for the owner-overlap case from #67 and share the recovery-module enable helper.

Fixes #67.

## Tests
- `forge fmt --check src/RecoverySpell.sol test/integration/RecoverySpells.t.sol`
- `forge test --match-contract RecoverySpellUnitTest -vv`
- `forge test --match-contract RecoverySpellsIntegrationTest -vv --fork-url $ETH_RPC_URL --libraries src/BytesHelper.sol:BytesHelper:0x146dfd96da039fde3b58d5964fef8e8357df2028`
- `forge test --mc UnitTest -vv`
- `forge build`
- `git diff --check`

## Notes
- I also ran the broader `forge test --mc IntegrationTest ...` mainnet-fork suite. The recovery suite passed; the broader run had two remaining failures outside the regression path: `testValidateDeployment` because this source change changes `RecoverySpellFactory` runtime/creation-code expectations versus the live address book, and `testMoveDaiFromMorphoToCompoundSucceed` with `Timelock: underlying transaction reverted` on the fork dependency path.